### PR TITLE
Change color of weak warning underwaved effect

### DIFF
--- a/One Dark.icls
+++ b/One Dark.icls
@@ -795,7 +795,7 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="333434" />
+        <option name="EFFECT_COLOR" value="9a9b9b" />
         <option name="ERROR_STRIPE_COLOR" value="ffffcc" />
         <option name="EFFECT_TYPE" value="2" />
       </value>


### PR DESCRIPTION
Changed color of the "weak warning" error stripe underwaved effect to increase visibility.